### PR TITLE
Kabiye: Ñ ñ Ɣ ɣ missing, ɤ not used, tones auxiliary

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -4085,7 +4085,8 @@ kbd:
 kbp:
   name: Kabiyè
   orthographies:
-  - base: A B C D Ɖ E Ɛ F G H I Ɩ J K L M N Ŋ O Ɔ P R S T U Ʋ V W Y Z a b c d ɖ e ɛ f g h i ɩ j k l m n ŋ o ɔ p r s t u ʋ v w y ɤ z ` ´
+  - base: A B C D Ɖ E Ɛ F G Ɣ H I Ɩ J K L M N Ñ Ŋ O Ɔ P R S T U Ʋ V W Y Z a b c d ɖ e ɛ f g ɣ h i ɩ j k l m n ñ ŋ o ɔ p r s t u ʋ v w y z
+    auxiliary: ` ´
     script: Latin
     status: primary
   source:


### PR DESCRIPTION
Letters Ɣ ɣ and Ñ ñ are used in Kabiye.

ɤ is not used, Ɣ ɣ is used instead.

Tones are usually not marked in spelling, this puts the tone marks in auxiliary.

See for example:
- https://www.webonary.org/kabiye/browse/browse-vernacular-english/?key=kbp&lang=en
- https://www.sil.org/resources/archives/1967
- https://www.bible.com/bible/555/MAT.1.KABI
- https://www.jw.org/kbp/