### PR TITLE
Madurese: <è e o â j ng> are letters for the sounds /ɛ ə ɨ ɔ ɤ ɟ ŋ/

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -5086,7 +5086,7 @@ mad:
   note: Latin script is the most used nowadays.
   orthographies:
   - autonym: Madhurâ
-    base: A B C D Ḍ E Ɛ Ə G H I Ɨ J K L M N Ŋ O Ɔ P R S T Ṭ U W Â a b c d ḍ e ɛ ə g h i ɨ j ɟ k l m n ŋ o ɔ p r s t ṭ u ɤ w â
+    base: A B C D Ḍ E G H I J K L M N O P R S T Ṭ U W Â a b c d ḍ e g h i j k l m n o p r s t ṭ u w â
     script: Latin
     status: primary
   - autonym: ꦧꦱꦴꦩꦝꦸꦫꦴ


### PR DESCRIPTION
Removing ɛ ə ɨ ɔ ɤ ɟ ŋ, which are phonetic symbols used in transcription, not letters used in orthography.

For example in https://en.wikipedia.org/wiki/Madurese_language#Phonology, the phonetic symbols are between slashes, like /ɛ/, and orthography letters are between angle brackets, like ⟨è⟩.