### PR TITLE
Adangme: add Ɛ ɛ Ɔ ɔ, drop C c Q q R r X x

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -239,14 +239,15 @@ acz:
 ada:
   name: Adangme
   orthographies:
-  - base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+  - base: A B D E Ɛ F G H I J K L M N O Ɔ P S T U V W Y Z a b d e ɛ f g h i j k l m n o ɔ p s t u v w y z
+    auxiliary: C Q R X c q r x
     script: Latin
     status: primary
   source:
   - Wikipedia
   speakers: 80000
   speakers_date: 2004
-  validity: weak
+  validity: done
 ady:
   name: Adyghe
   orthographies:


### PR DESCRIPTION
Based on Bureau of Ghana Languages, *Language Guide: Dangme Version*, 1990 and Rhonda L. Hartell, *Alphabets of Africa*, 1993

See for example [Bureau of Ghana Languages 1990](https://books.google.com/books?id=VsMiAQAAMAAJ) page 5:
![Bureau of Ghana Languages, Language Guide - Dangme, 1990](https://user-images.githubusercontent.com/1923747/111921336-ef037300-8a8b-11eb-84d9-28b10d4b4dd2.jpg)
or [Hartell 1993](https://archive.org/details/rosettaproject_ada_ortho-1) page 150.