### PR TITLE
Basa (Cameroon): combining marks for ɛ ɔ

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -1030,7 +1030,7 @@ bas:
   orthographies:
   - autonym: Basaa
     auxiliary: Q X q x
-    base: A B C D E F G H I J K L M N O P R S T U V W Y Z À Á Â È É Ê Ì Í Î Ò Ó Ô Ù Ú Û Ā Ē Ě Ī Ń Ŋ Ō Ū Ǎ Ǐ Ǒ Ǔ Ǹ Ɓ Ɔ Ɛ a b c d e f g h i j k l m n o p r s t u v w y z à á â è é ê ì í î ò ó ô ù ú û ā ē ě ī ń ŋ ō ū ǎ ǐ ǒ ǔ ǹ ɓ ɔ ɛ ᷆ ᷇
+    base: A B C D E F G H I J K L M N O P R S T U V W Y Z À Á Â È É Ê Ì Í Î Ò Ó Ô Ù Ú Û Ā Ē Ě Ī Ń Ŋ Ō Ū Ǎ Ǐ Ǒ Ǔ Ǹ Ɓ Ɔ Ɛ a b c d e f g h i j k l m n o p r s t u v w y z à á â è é ê ì í î ò ó ô ù ú û ā ē ě ī ń ŋ ō ū ǎ ǐ ǒ ǔ ǹ ɓ ɔ ɛ ́ ̀ ̂ ̌ ̄ ᷆ ᷇
     script: Latin
     status: primary
   source:


### PR DESCRIPTION
Basa (Cameroon) uses combining grave, combining acute, combining circumflex, combining macron and combining caron on Ɛ Ɔ ɛ ɔ, as shown in the CLDR bas exemplar character set (see "Basaa" on https://unicode-org.github.io/cldr-staging/charts/latest/by_type/core_data.alphabetic_information.main.html).
For some reason, they were removed in Hypherglot data, while they remained on precomposed characters (À Á Â È É Ê etc.).