### PR TITLE
Aja (Benin): acute, grave used on any vowel, circumflex and caron not used

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -435,13 +435,17 @@ ajg:
   name: Aja (Benin)
   orthographies:
   - autonym: Adja
-    base: A B C D Ɖ E Ɛ F G Ɣ H I J K L M N Ŋ O Ɔ P R S T U V W X Y Z Ʒ Á À Ă Â a b c d ɖ e ɛ f g ɣ h i j k l m n ŋ o ɔ p r s t u v w x y z ʒ á à ă â
-    marks: ̀  ́  ̂  ̆
+    base: A B C D Ɖ E Ɛ F G Ɣ H I J K L M N Ŋ O Ɔ P R S T U V W X Y Z Ʒ À Á È É Ì Í Ò Ó Ù Ú a b c d ɖ e ɛ f g ɣ h i j k l m n ŋ o ɔ p r s t u v w x y z ʒ à á è é ì í ò ó ù ú
+    marks:  ̀ ́
     script: Latin
     status: primary
   source:
+  - Virginia Beavon-Ham, Emile Ega, Lire et écrire l'ajagbe (Guide pratique pour ceux qui savent lire le français), 2007, https://www.sil.org/resources/archives/35562.
+  - Centre national de linguistique appliquée (C.E.N.A.L.A.), Alphabet des langues nationales béninoises, 2008, p. 5-6.
+  - Eric A. Morley, A Grammar of Ajagbe, 2010.
   - Omniglot
   - Wikipedia
+  - https://www.jw.org/ajg
   speakers: 550000
   speakers_date: 2006-2012
   validity: preliminary


### PR DESCRIPTION
Beavon-Ham and Ega 2007 and Morley 2001 mention acute and grave used for high and low tone on ambiguous monosyllabic words. This removes Â â Ă ă and adds precomposed accented vowels with acute and grave, and also adjusts the mark field accordingly.

Note: CENALA 2008 does not mention tone marks in Aja orthography, but uses acute, grave, circumflex, caron, macron for high, low, descending, ascending and middle tone in the general Benin languages alphabet. Omniglot indicating the letter a with breve being used is definitely wrong.

See https://www.jw.org/ajg for example.