### PR TITLE
Remove U+0B82 TAMIL SIGN ANUSVARA from Tamil marks

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -8454,7 +8454,7 @@ tam:
   - autonym: தமிழ்
     base: அ ஆ இ ஈ உ ஊ எ ஏ ஐ ஒ ஓ ஔ ஃ க ங ச ஞ ட ண த ந ப ம ய ர ல வ ழ ள ற ன ஜ ஶ ஷ ஸ ஹ
     design_note: Mark positioning and numerous precomposed forms (namely conjunct ligatures) are required for proper representation of the language.
-    marks: ஂ  ா  ி  ீ  ு  ூ  ெ  ே  ை  ்  ௗ
+    marks: ா  ி  ீ  ு  ூ  ெ  ே  ை  ்  ௗ
     numerals: 0 ௧ ௨ ௩ ௪ ௫ ௬ ௭ ௮ ௯ ௰ ௱ ௲ 1 2 3 4 5 6 7 8 9
     script: Tamil
     status: primary


### PR DESCRIPTION
[The code chart](https://www.unicode.org/charts/PDF/U0B80.pdf) says it is “not used in Tamil”.