### PR TITLE
Update Minangkabau

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -5893,8 +5893,7 @@ min:
   name: Minangkabau
   orthographies:
   - autonym: Baso Minangkabau
-    base: A B C D E F G H I J K L M N O P Q R S T U W Y Ē Ñ a b c d e f g h i j k l m n o p q r s t u w y ē ñ
-    marks: ̃  ̄
+    base: A B C D E F G H I J K L M N O P Q R S T U V W Y Z a b c d e f g h i j k l m n o p q r s t u v w y z
     script: Latin
     status: primary
   source:


### PR DESCRIPTION
Well I don't speak fluent Minangkabau, but I can comprehend the language.

Absolutely no diacritics in Minangkabau. 

From [a dictionary I've consulted](http://repositori.kemdikbud.go.id/2947/1/Kamus%20Minangkabau%20-%20Indonesia%20-%20335h.pdf), F, Q, V, and X "are not native phonemes" but I found that F, Q, and Z used pretty frequently. V is also used occasionally. Not sure about X but it's a rare letter even in Indonesian.

Still let the status as "primary". Needs confirmation from native speakers.