### PR TITLE
About Minang(kabau)

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -5893,8 +5893,7 @@ min:
   name: Minangkabau
   orthographies:
   - autonym: Baso Minangkabau
-    base: A B C D E F G H I J K L M N O P Q R S T U W Y Ē Ñ a b c d e f g h i j k l m n o p q r s t u w y ē ñ
-    marks: ̃  ̄
+    base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z 
     script: Latin
     status: primary
   source:
@@ -9626,21 +9625,6 @@ xog:
   - CLDR
   speakers: 3600000
   speakers_date: 2014
-  status: living
-  validity: verified
-xrg:
-  name: Minang
-  note: ISO 639-3 has this language marked as extinct while Wikipedia reports L1 speakers.
-  orthographies:
-  - autonym: Minangkabau
-    base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-    script: Latin
-    status: primary
-  source:
-  - Omniglot
-  - Wikipedia
-  speakers: 6401000
-  speakers_date: 2007-2016
   status: living
   validity: verified
 xsm:


### PR DESCRIPTION
The ISO 639-3:xrg is an extinct dialect of ISO 639-3:nys and is not "Minangkabau" (ISO 639-3:min). (https://iso639-3.sil.org/sites/iso639-3/files/change_requests/2012/2012-015_xrg.pdf) (https://en.wikipedia.org/wiki/Nyungar_language) (https://www.ethnologue.com/language/xrg)

About ISO 639-3:min, there are no diacritics whatsoever. F, Q, V, and Z, despite being "non-native phonemes" (http://repositori.kemdikbud.go.id/2947/1/Kamus%20Minangkabau%20-%20Indonesia%20-%20335h.pdf), are used pretty frequently. X, it's a very rare letter, but I found that "verified" Javanese and Sundanese have also included that letter (which means it's the exact same with Indonesian?), so yeah.

Still debating on keeping this "preliminary" or "verified".