### PR TITLE
Aux

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -8138,7 +8138,8 @@ sms:
   name: Skolt Sami
   orthographies:
   - autonym: Nuõrttsääʹmǩiõll
-    base: A B C D E F G H I J K L M N O P Q R S T U V X Y Z Â Ä Å Ö Õ Č Đ Ŋ Š Ž Ǥ Ǧ Ǩ Ǯ Ʒ a b c d e f g h i j k l m n o p q r s t u v x y z â ä å ö õ č đ ŋ š ž ǥ ǧ ǩ ǯ ʒ ’ ʹ ˈ
+    auxiliary: Å Ö å ö 
+    base: A B C D E F G H I J K L M N O P Q R S T U V X Y Z Â Ä Õ Č Đ Ŋ Š Ž Ǥ Ǧ Ǩ Ǯ Ʒ a b c d e f g h i j k l m n o p q r s t u v x y z â ä õ č đ ŋ š ž ǥ ǧ ǩ ǯ ʒ ’ ʹ ˈ
     marks: ̂  ̃  ̈  ̊  ̌
     script: Latin
     status: primary


### PR DESCRIPTION
These letters are only used in loanwords (or proper nouns) from Finnish/Swedish. Norwegian Ø would potentially be a relevant letter in loanwords, too. Because Skolt Sami is now recognized in Norway, too.