### PR TITLE
Minor fix preventing ü redundancy in Portuguese

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -7503,7 +7503,7 @@ por:
   orthographies:
   - autonym: Português
     auxiliary: Ü ü
-    base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z À Á Â Ã Ç È É Ê Í Ò Ó Ô Õ Ú a b c d e f g h i j k l m n o p q r s t u v w x y z à á â ã ç è é ê í ò ó ô õ ú ü
+    base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z À Á Â Ã Ç È É Ê Í Ò Ó Ô Õ Ú a b c d e f g h i j k l m n o p q r s t u v w x y z à á â ã ç è é ê í ò ó ô õ ú
     marks: ◌̀ ◌́ ◌̂ ◌̃ ◌̈ ◌̧
     script: Latin
     status: primary


### PR DESCRIPTION
Removing ü `u+00FC` as a base character in Portuguese as it is also listed as an auxiliary character.
related issue: https://github.com/rosettatype/hyperglot/issues/61