### PR TITLE
Hawaiian okina correction

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -4074,8 +4074,8 @@ hau:
 haw:
   name: Hawaiian
   orthographies:
-  - autonym: ’Olelo Hawai’i
-    base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ā Ē Ī Ō Ū a b c d e f g h i j k l m n o p q r s t u v w x y z ā ē ī ō ū ’
+  - autonym: ʻOlelo Hawaiʻi
+    base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ā Ē Ī Ō Ū a b c d e f g h i j k l m n o p q r s t u v w x y z ā ē ī ō ū ʻ
     marks: ◌̄
     script: Latin
     status: primary


### PR DESCRIPTION
Hawaiian okina consonant is represented by U+02BB MODIFIER LETTER TURNED COMMA. Previously hyperglot.yaml listed it as right apostrophe.

Source: https://en.wikipedia.org/wiki/%CA%BBOkina