### PR TITLE
On backslash

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -11453,7 +11453,7 @@ zsm:
   name: Standard Malay
   orthographies:
   - autonym: Malaysia
-    auxiliary: '
+    auxiliary: "'"
     base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
     note: Post-1972 orthography (without diacritics) is used by Standard Malay and Indonesian.
     script: Latin

--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -11453,7 +11453,7 @@ zsm:
   name: Standard Malay
   orthographies:
   - autonym: Malaysia
-    auxiliary: \'
+    auxiliary: '
     base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
     note: Post-1972 orthography (without diacritics) is used by Standard Malay and Indonesian.
     script: Latin


### PR DESCRIPTION
I found some error on the app, and that's the backslash is shown as a separate codepoint in the orthography, which we actually never use in our orthography. I would like to fix the problem by removing the said symbol. But I don't know whether or not it's something technical. Hopefully not.