### PR TITLE
Kom (bkm) and  Southern Samo (sbd) fixes

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -1789,7 +1789,7 @@ bjt:
 bkm:
   name: Kom (Cameroon)
   orthographies:
-  - base: A Æ B C D E F G H I Ɨ J ’ K L M N N Ŋ O Œ S T U V W Y Z a æ b c d e f g h i ɨ j k l m n n ŋ o œ s t u v w y z À Æ̀ È Ì Ɨ̀ Ò Œ̀ Ù Â Æ̂ Ê Î Ɨ̂ Ô Œ̂ Û à æ̀ è ì ɨ̀ ò œ̀ ù â æ̂ ê î ɨ̂ ô œ̂ û
+  - base: A Æ B C D E F G H I Ɨ J ’ K L M N NY Ŋ O Œ S T U V W Y Z a æ b c d e f g h i ɨ j k l m n ny ŋ o œ s t u v w y z À Æ̀ È Ì Ɨ̀ Ò Œ̀ Ù Â Æ̂ Ê Î Ɨ̂ Ô Œ̂ Û à æ̀ è ì ɨ̀ ò œ̀ ù â æ̂ ê î ɨ̂ ô œ̂ û
     design_requirements:
     - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in Afrikan languages, and the other resembling N with J as the second stem favoured in Sami languages.
     marks: ◌̀ ◌̂

--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -9600,7 +9600,7 @@ sbd:
   name: Southern Samo
   orthographies:
   - auxiliary: G H J Q Z g h j q z
-    base: A B C D E Ɛ Ə F I K L M N Ŋ O Ɔ P R S T U W Y a b c d e ɛ ə f i k l m n ŋ o ɔ p r s t u w y À È Ɛ̀ Ə̀ Ì Ǹ Ò Ɔ̀ Ù À È Ì Ń Ò Ù Ǎ Ě Ə̌ Ɛ̌ Ǐ Ǒ Ɔ̌ Ǔ Ä Ë Ɛ̈ Ə̈ Ï Ö Ɔ̈ Ü Ã Ĩ Ɔ̃ Ũ à è ɛ̀ ə̀ ì ò ɔ̀ ù á é ɛ́ ə́ í ó ɔ́ ú ǎ ě ɛ̌ ə̌ ǐ ǒ ɔ̌ ǔ ä ë ɛ̈ ə̈ ï ö ɔ̈ ü ã ĩ ɔ̃ ũ
+    base: A B C D E Ɛ Ə F I K L M N Ŋ O Ɔ P R S T U W Y a b c d e ɛ ə f i k l m n ŋ o ɔ p r s t u w y À È Ɛ̀ Ə̀ Ì Ǹ Ò Ɔ̀ Ù Á É Í Ń Ó Ú Ǎ Ě Ə̌ Ɛ̌ Ǐ Ǒ Ɔ̌ Ǔ Ä Ë Ɛ̈ Ə̈ Ï Ö Ɔ̈ Ü Ã Ĩ Ɔ̃ Ũ à è ɛ̀ ə̀ ì ǹ ò ɔ̀ ù á é ɛ́ ə́ í ń ó ɔ́ ú ǎ ě ɛ̌ ə̌ ǐ ǒ ɔ̌ ǔ ä ë ɛ̈ ə̈ ï ö ɔ̈ ü ã ĩ ɔ̃ ũ
     design_requirements:
     - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in Afrikan languages, and the other resembling N with J as the second stem favoured in Sami languages.
     marks: ◌̀ ◌́ ◌̌ ◌̈ ◌̃


### PR DESCRIPTION
- duplicate n in bkm is ny
- lowercase ń and ǹ in sbd missing while uppecase is present