### PR TITLE
nav: ogonek position typically is the same as Polish or Lithuanian

### DIFF
--- a/lib/hyperglot/hyperglot.yaml
+++ b/lib/hyperglot/hyperglot.yaml
@@ -8007,7 +8007,7 @@ nav:
     base: A Ą B C D E Ę G H I Į J K L Ł M N O Ǫ S T W X Y Z a á ą ą́ b c d e é ę ę́ g h i í į į́ j k l ł m n o ó ǫ ǫ́ s t w x y z ʼ
     design_alternates: Ą Ę Į Ǫ ą ą́ ę ę́ į į́ ǫ ǫ́
     design_requirements:
-    - The positioning of the ogonek mark (marked in the previews) differs from its positioning in Polish and Lithuanian as it is typically centered below the vowel.
+    - The positioning of the ogonek mark (marked in the previews) sometimes differs from its positioning in Polish and Lithuanian, but it is typically positioned as in those languages.
     marks: ◌́ ◌̨
     script: Latin
     status: primary


### PR DESCRIPTION
While the ogonek position is centered in some works, it is also on the right in several works

See https://github.com/adobe-fonts/source-sans/issues/75\#issuecomment-771293028