### PR TITLE
kkj: remove Ǌ, add mbonjɔɔ orthography, add missing cedilla vowels

### DIFF
--- a/lib/hyperglot/data/kkj.yaml
+++ b/lib/hyperglot/data/kkj.yaml
@@ -1,8 +1,16 @@
 name: Kako
 orthographies:
-- autonym: Kakɔ
+- autonym: kakɔ
   auxiliary: Q X Z q x z
-  base: A B C D E F G H I J K L M N O P R S T U V W Y À Á Â È É Ê Ì Í Î Ò Ó Ô Ù Ú Û Ŋ Ǌ Ɓ Ɔ Ɗ Ɛ a b c d e f g h i j k l m n o p r s t u v w y à á â è é ê ì í î ò ó ô ù ú û ŋ ǌ ɓ ɔ ɗ ɛ
+  base: A B Ɓ C D Ɗ E Ɛ F G H I J K L M N Ŋ O Ɔ P R S T U V W Y À Á Â È É Ê Ɛ̀ Ɛ́ Ɛ̂ Ì Í Î Ò Ó Ô Ɔ̀ Ɔ́ Ɔ̂ Ù Ú Û A̧ Ɛ̧ I̧ Ɔ̧ U̧ a b ɓ c d ɗ e ɛ f g h i j k l m n ŋ o ɔ p r s t u v w y à á â è é ê ɛ̀ ɛ́ ɛ̂ ì í î ò ó ô ɔ̀ ɔ́ ɔ̂ ù ú û a̧ ɛ̧ i̧ ɔ̧ u̧
+  design_requirements:
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in Afrikan languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  marks: ◌̀ ◌́ ◌̂ ◌̧
+  script: Latin
+  status: primary
+- autonyme: mbonjɔɔ
+  auxiliary: Q X q x
+  base: A B Ɓ C D Ɗ E Ɛ F G H I J K L M N Ŋ O Ɔ P R S T U V W Y Z À Á Â È É Ê Ɛ̀ Ɛ́ Ɛ̂ Ì Í Î Ò Ó Ô Ɔ̀ Ɔ́ Ɔ̂ Ù Ú Û A̧ I̧ U̧ a b ɓ c d ɗ e ɛ f g h i j k l m n ŋ o ɔ p r s t u v w y z à á â è é ê ɛ̀ ɛ́ ɛ̂ ì í î ò ó ô ɔ̀ ɔ́ ɔ̂ ù ú û a̧ i̧ u̧
   design_requirements:
   - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in Afrikan languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̂ ◌̧
@@ -11,6 +19,8 @@ orthographies:
 source:
 - CLDR
 - Wikipedia
+- Ernst Urs, Alphabet et orthographe du kakɔ (kakɔ-est), SIL Cameroun, 1996
+- Ernst Urs, Alphabet et orthographe du mbonjɔɔ (kakɔ-ouest), SIL Cameroun, 1996
 speakers: 120000
 speakers_date: 1996-2003
 status: living


### PR DESCRIPTION
- remove single character Ǌ ǌ as digraph NJ nj are used instead
- add mbonjɔɔ orthography
- add cedilla vowels: A̧ Ɛ̧ I̧ Ɔ̧ U̧ a̧ ɛ̧ i̧ ɔ̧ u̧ used for nasalization
- sources (https://www.sil.org/system/files/reapdata/17/99/67/17996750375684415583714939068611628912/KakoEast1996PaginatedwithTableofContents.pdf and https://www.sil.org/system/files/reapdata/41/85/69/41856909488715868347280840615944394423/KakoWest1996PaginatedwithTableofContents.pdf) 