### PR TITLE
sco: ȝ not used in Modern Scots (1700-now)

### DIFF
--- a/lib/hyperglot/data/sco.yaml
+++ b/lib/hyperglot/data/sco.yaml
@@ -1,7 +1,7 @@
 name: Scots
 orthographies:
 - autonym: Scots Leid
-  base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ȝ a b c d e f g h i j k l m n o p q r s t u v w x y z ȝ
+  base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
   script: Latin
   status: primary
 source:


### PR DESCRIPTION
See for example [https://dsl.ac.uk/results/"ȝ"](https://dsl.ac.uk/results/"ȝ") with 0 results in the Scottish National Dictionary (1700 onwards) but with results in A Dictionary of the Older Scottish Tongue (prior to 1700).