### PR TITLE
Sync Ŋ note

### DIFF
--- a/lib/hyperglot/data/ach.yaml
+++ b/lib/hyperglot/data/ach.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Acoli
   base: A B C D E G I J K L M N Ŋ O P R T U W Y a b c d e g i j k l m n ŋ o p r t u w y
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/ade.yaml
+++ b/lib/hyperglot/data/ade.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Gɩdɩrɛ
   base: A B D E F G H I K L M N O P R S T U W Y a b d e f g h i k l m n o p r s t u w y Ŋ ŋ Ɔ Ɛ Ɩ Ʋ ɔ ɛ ɩ ʋ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/agq.yaml
+++ b/lib/hyperglot/data/agq.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Q R X q r x
   base: A B C D E F G H I K L M N O P S T U V W Y Z À Â È Ê Ì Î Ò Ô Ù Û Ā Ē Ě Ī Ŋ Ō Ū Ǎ Ǐ Ǒ Ǔ Ɔ Ɛ Ɨ Ʉ a b c d e f g h i k l m n o p s t u v w y z à â è ê ì î ò ô ù û ā ē ě ī ŋ ō ū ǎ ǐ ǒ ǔ ɔ ɛ ɨ ʉ ʔ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌̂ ◌̄ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/ajg.yaml
+++ b/lib/hyperglot/data/ajg.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Adja
   base: A B C D E F G H I J K L M N O P R S T U V W X Y Z a b c d e f g h i j k l m n o p r s t u v w x y z À Á È É Ì Í Ò Ó Ù Ú à á è é ì í ò ó ù ú Ŋ ŋ Ɔ Ɖ Ɛ Ɣ Ʒ ɔ ɖ ɛ ɣ ʒ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́
   script: Latin
   status: primary

--- a/lib/hyperglot/data/avn.yaml
+++ b/lib/hyperglot/data/avn.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Sia
   base: A B D E F G H I K L M N O P R S T U V W X Y Z a b d e f g h i k l m n o p r s t u v w x y z Ŋ ŋ Ɔ Ɖ Ɛ Ƒ ƒ Ʋ ɔ ɖ ɛ ʋ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/azo.yaml
+++ b/lib/hyperglot/data/azo.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: awing
   base: A B C D E F G H I J K L M N O P S T U W Y Z a b c d e f g h i j k l m n o p s t u w y z Á Â É Ê Í Î Ó Ô Ú Û á â é ê í î ó ô ú û Ě ě Ŋ ŋ Ɔ Ə Ɛ Ɨ Ǎ ǎ Ǐ ǐ Ǒ ǒ Ǔ ǔ ɔ ə ɛ ɨ ʼ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̂ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/bam.yaml
+++ b/lib/hyperglot/data/bam.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Q V X q v x
   base: A B C D E F G H I J K L M N O P R S T U W Y Z Ŋ Ɔ Ɛ Ɲ a b c d e f g h i j k l m n o p r s t u w y z ŋ ɔ ɛ ɲ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/bas.yaml
+++ b/lib/hyperglot/data/bas.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Q X q x
   base: A B C D E F G H I J K L M N O P R S T U V W Y Z À Á Â È É Ê Ì Í Î Ò Ó Ô Ù Ú Û Ā Ē Ě Ī Ń Ŋ Ō Ū Ǎ Ǐ Ǒ Ǔ Ǹ Ɓ Ɔ Ɛ a b c d e f g h i j k l m n o p r s t u v w y z à á â è é ê ì í î ò ó ô ù ú û ā ē ě ī ń ŋ ō ū ǎ ǐ ǒ ǔ ǹ ɓ ɔ ɛ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̂ ◌̄ ◌̌ ◌᷆ ◌᷇
   script: Latin
   status: primary

--- a/lib/hyperglot/data/bbo.yaml
+++ b/lib/hyperglot/data/bbo.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: kʋnabɩrɩ
   base: A B D E Ɛ F G H I Ɩ J K L M N Ɲ Ŋ O Ɔ P R S T U Ʋ V W Y a b d e ɛ f g h i ɩ j k l m n ɲ ŋ o ɔ p r s t u ʋ v w y
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/bfa.yaml
+++ b/lib/hyperglot/data/bfa.yaml
@@ -2,7 +2,7 @@ name: Bari
 orthographies:
 - base: A B D E G I J K L M N O P R S T U W Y Ŋ Ö a b d e g i j k l m n o p r s t u w y ŋ ö '
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̈
   script: Latin
   status: primary

--- a/lib/hyperglot/data/bib.yaml
+++ b/lib/hyperglot/data/bib.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: C J Ʊ c j ʊ
   base: A B D E Ɛ Ə F G H I Ɩ K L M N Ɲ Ŋ O Ɔ P R S T U Ʋ W Y Z a b d e ɛ ə f g h i ɩ k l m n ɲ ŋ o ɔ p r s t u ʋ w y z À à Á á
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́
   script: Latin
   status: primary

--- a/lib/hyperglot/data/bjt.yaml
+++ b/lib/hyperglot/data/bjt.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: balant
   base: A B D E F G H I J L M N O R S T U W Y a b d e f g h i j l m n o r s t u w y Ñ ñ Ŋ ŋ Ŧ ŧ Ɓ ɓ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/bkm.yaml
+++ b/lib/hyperglot/data/bkm.yaml
@@ -2,7 +2,7 @@ name: Kom (Cameroon)
 orthographies:
 - base: A Æ B C D E F G H I Ɨ J ’ K L M N NY Ŋ O Œ S T U V W Y Z a æ b c d e f g h i ɨ j k l m n ny ŋ o œ s t u v w y z À Æ̀ È Ì Ɨ̀ Ò Œ̀ Ù Â Æ̂ Ê Î Ɨ̂ Ô Œ̂ Û à æ̀ è ì ɨ̀ ò œ̀ ù â æ̂ ê î ɨ̂ ô œ̂ û
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌̂
   script: Latin
   status: primary

--- a/lib/hyperglot/data/blo.yaml
+++ b/lib/hyperglot/data/blo.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: anii
   base: A B C E F G H I J K L M N O P R S T U W Y a b c e f g h i j k l m n o p r s t u w y À Á Â È É Ê Ì Í Î Ò Ó Ô Ù Ú Û à á â è é ê ì í î ò ó ô ù ú û Ŋ ŋ Ɔ Ɖ Ǝ Ɛ Ɩ Ʊ ǝ ɔ ɖ ɛ ɩ ʊ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̀ ◌̂
   script: Latin
   status: primary

--- a/lib/hyperglot/data/boz.yaml
+++ b/lib/hyperglot/data/boz.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: bozo-tigemaxoo
   base: A B C D E F G H I J K L M N O P R S T U W X Y a b c d e f g h i j k l m n o p r s t u w x y Ŋ ŋ Ɔ Ɛ Ɲ ɔ ɛ ɲ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/bsc.yaml
+++ b/lib/hyperglot/data/bsc.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: oniyan
   base: A B C D E F G H I J K L M N O P R S T U W Y a b c d e f g h i j k l m n o p r s t u w y É Ë Ñ Ó é ë ñ ó Ĥ ĥ Ŋ ŋ Ŝ ŝ Ŵ ŵ Ŷ ŷ Ɓ Ɗ Ƴ ƴ ɓ ɗ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̈ ◌̂ ◌̃
   note: Senegal
   script: Latin
@@ -11,7 +11,7 @@ orthographies:
 - autonym: oneyan
   base: A B C D E F G H I J K L M N O P R S T U V W Y a b c d e f g h i j k l m n o p r s t u v w y Ŋ ŋ Ɓ Ɔ Ɗ Ǝ Ɛ Ɲ Ʃ Ƴ ƴ ǝ Ɉ ɉ ɓ ɔ ɗ ɛ ɲ ʃ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   note: Guinea
   script: Latin
   status: primary

--- a/lib/hyperglot/data/bss.yaml
+++ b/lib/hyperglot/data/bss.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Akɔɔse
   base: A B D E F G H I J K L M N O P R S T U V W Y a b d e f g h i j k l m n o p r s t u v w y á â é ê í î ó ô ú û ě Ŋ ŋ Ɔ Ə Ɛ ǎ ǐ ǒ ǔ ɔ ə ɛ ʼ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̂ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/byv.yaml
+++ b/lib/hyperglot/data/byv.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Mə̀dʉ̂mbɑ̀
   base: A B C D E F G H I J K L M N O S T U V W Y Z a b c d e f g h i j k l m n o s t u v w y z À Â È Ê Ì Î Ò Ô Ù Û à â è ê ì î ò ô ù û Ě ě Ŋ ŋ Ɔ Ə Ɛ Ǎ ǎ Ǐ ǐ Ǒ ǒ Ǔ ǔ Ʉ ɑ ɔ ə ɛ ʉ ʼ Ɑ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌̂ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/bze.yaml
+++ b/lib/hyperglot/data/bze.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: bozo-jenaama
   base: A B C D E F G H I J K L M N O P R S T U W Y a b c d e f g h i j k l m n o p r s t u w y Ŋ ŋ Ɔ Ɛ Ɲ ɔ ɛ ɲ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/cko.yaml
+++ b/lib/hyperglot/data/cko.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Anufo
   base: A B C D E F G H I J K L M N O P R S T U V W Y Z a b c d e f g h i j k l m n o p r s t u v w y z Ŋ ŋ Ɔ Ɛ ɔ ɛ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/cme.yaml
+++ b/lib/hyperglot/data/cme.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: cerma
   base: A B C D E Ɛ F G H I K L M N Ŋ O Ɔ P R S T U V W Y a b c d e ɛ f g h i k l m n ŋ o ɔ p r s t u v w y Ã Ĩ Ũ ã ĩ ũ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/cmn.yaml
+++ b/lib/hyperglot/data/cmn.yaml
@@ -14,7 +14,7 @@ orthographies:
 - autonym: Pǔtōnghuà
   base: A B C D E F G H I J K L M N O P Q R S T U W X Y Z a b c d e f g h i j k l m n o p q r s t u w x y z ü Ü ê Ê ĉ ŝ ẑ ŋ Ĉ Ŝ Ẑ Ŋ ā ē ī ō ū ǖ ê̄ m̄ n̄ Ā Ē Ī Ō Ū Ǖ Ê̄ M̄ N̄ á é í ó ú ǘ ế ḿ ń Á É Í Ó Ú Ǘ Ế Ḿ Ń ǎ ě ǐ ǒ ǔ ǚ ê̌ m̌ ň Ǎ Ě Ǐ Ǒ Ǔ Ǚ Ê̌ M̌ Ň à è ì ò ù ǜ ề m̀ ǹ À È Ì Ò Ù Ǜ Ề M̀ Ǹ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̂ ◌̄ ◌̈ ◌̌
   note: Hànyǔ Pīnyīn (Hànyǔ Pīnyīn (pinyin)) is the official romanization system for Standard Mandarin Chinese in mainland China, Taiwan (ROC), and Singapore.
   punctuation: . , — … · - '

--- a/lib/hyperglot/data/cou.yaml
+++ b/lib/hyperglot/data/cou.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: wamey
   base: A B D E F G H I K L M N O P R S T U W X Y a b d e f g h i k l m n o p r s t u w x y Ŋ ŋ Ɔ Ǝ Ɛ Ɲ ǝ ɔ ɛ ɲ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/dag.yaml
+++ b/lib/hyperglot/data/dag.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Dagbanli
   base: A B C D E F G H I J K L M N O P R S T U V W Y Z Ɛ Ɣ Ɨ Ŋ Ɔ Ʒ a b c d e f g h i j k l m n o p r s t u v w y z ' ɛ ɣ ɨ ŋ ɔ ʒ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   note: Ʒ is sometimes encountered written as reversed "Σ" without unicode encoding, see https://github.com/rosettatype/hyperglot/issues/138
   script: Latin
   status: primary

--- a/lib/hyperglot/data/ddn.yaml
+++ b/lib/hyperglot/data/ddn.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Dandawa
   base: A B C D E Ɛ F G H I J K L M N Ŋ O Ɔ P R S T W Y Z À Á Ā È É Ē Ì Í Ī Ò Ó Ō Ù Ú Ū a b c d e ɛ f g h i j k l m n ŋ o ɔ p r s t w y z à á ā è é ē ì í ī ò ó ō ù ú ū
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̄
   script: Latin
   status: primary

--- a/lib/hyperglot/data/dga.yaml
+++ b/lib/hyperglot/data/dga.yaml
@@ -3,13 +3,13 @@ orthographies:
 - auxiliary: Ɦ ɦ Ŋ ŋ
   base: A B D E Ɛ F G H I J K L M N O Ɔ P R S T U V W Y Z a b d e ɛ f g h i j k l m n o ɔ p r s t u v w y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   note: Bureau of Ghana Languages orthography. Ɦ and Ŋ are proposed in Bodomo 1997.
   script: Latin
   status: primary
 - base: A B D E Ɛ F G H I J K L M N Ŋ O Ɔ P R S T U V W Y Z a b d e ɛ f g h i j k l m n ŋ o ɔ p r s t u v w y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̃
   note: Bible Society of Ghana orthography
   script: Latin

--- a/lib/hyperglot/data/dgi.yaml
+++ b/lib/hyperglot/data/dgi.yaml
@@ -2,7 +2,7 @@ name: Northern Dagara
 orthographies:
 - base: A B Ɓ C D E Ɛ F G H I Ɩ J K L M N Ŋ O Ɔ P R S T U Ʋ V W Y Ƴ Z a b ɓ c d e ɛ f g h i ɩ j k l m n ŋ o ɔ p r s t u ʋ v w y ƴ z À È Ɛ̀ Ì Ò Ɔ̀ Ù Á É Ɛ́ Í Ó Ɔ́ Ú Ã Ẽ Ɛ̃ Õ Ɔ̃ à è ɛ̀ ì ò ɔ̀ ù á é ɛ́ í ó ɔ́ ú ã ẽ ɛ̃ õ ɔ̃
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/din.yaml
+++ b/lib/hyperglot/data/din.yaml
@@ -2,7 +2,7 @@ name: Dinka
 orthographies:
 - base: A B C D E Ɛ G Ɣ I K L M N Ŋ O Ɔ P R S T U W Y Ä Ë Ï Ö a b c d e ɛ g ɣ i k l m n ŋ o ɔ p r s t u w y ä ë ï ö
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̈
   script: Latin
   status: primary

--- a/lib/hyperglot/data/dje.yaml
+++ b/lib/hyperglot/data/dje.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Zarmaciine
   base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ŋ Ɲ À Á Ã Ǎ Í Õ Ǒ Ô Š Ẽ Ě Ê Ž a b c d e f g h i j k l m n o p q r s t u v w x y z ŋ ɲ à á ã ǎ í õ ǒ ô š ẽ ě ê ž
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̂ ◌̃ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/dno.yaml
+++ b/lib/hyperglot/data/dno.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Ndrǔló
   base: A B D E F G H Ɦ I J K L M N Ŋ O P R S T U V W Y Z a b d e f g h ɦ i j k l m n ŋ o p r s t u v w y z Â Ê Î Ô R̂ Û Á É Í Ó Ŕ Ś Ú À È Ì Ò R̀ S̀ Ù Ǎ Ě Ǐ Ǒ Ř Š Ǔ â ê î ô r̂ û á é í ó ŕ ś ú à è ì ò r̀ s̀ ù ǎ ě ǐ ǒ ř š ǔ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̂ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/dop.yaml
+++ b/lib/hyperglot/data/dop.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: lǝkpa
   base: A C E Ɛ Ǝ F H I Ɩ K L M N Ŋ Ŋ O Ɔ P Ɣ S T U Ʊ W Y Á É Ú Ḿ Ń a c e ɛ ǝ f h i ɩ k l m n ŋ ŋ o ɔ p ɣ s t u ʊ w y á é ú ḿ ń
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́
   script: Latin
   status: primary

--- a/lib/hyperglot/data/dua.yaml
+++ b/lib/hyperglot/data/dua.yaml
@@ -5,7 +5,7 @@ orthographies:
   auxiliary: H Q V X Z h q v x z
   base: A B C D E F G I J K L M N O P R S T U W Y Á É Í Ó Ú Ŋ Ū Ɓ Ɔ Ɗ Ɛ a b c d e f g i j k l m n o p r s t u w y á é í ó ú ŋ ū ɓ ɔ ɗ ɛ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̄
   script: Latin
   status: primary

--- a/lib/hyperglot/data/dyo.yaml
+++ b/lib/hyperglot/data/dyo.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Z z
   base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Á É Í Ñ Ó Ú Ŋ a b c d e f g h i j k l m n o p q r s t u v w x y á é í ñ ó ú ŋ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/dyu.yaml
+++ b/lib/hyperglot/data/dyu.yaml
@@ -4,7 +4,7 @@ orthographies:
 - autonym: Julakan
   base: A B C D E Ɛ F G H I J K L M N Ɲ Ŋ O Ɔ P R S T U V W Y Z a b c d e ɛ f g h i j k l m n ɲ ŋ o ɔ p r s t u v w y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 - autonym: ߖߎ߬ߟߊ߬ߞߊ߲

--- a/lib/hyperglot/data/pil.yaml
+++ b/lib/hyperglot/data/pil.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Ʋ ʋ
   base: A B C D E Ɛ Ǝ F G H I J K L M N Ŋ O Ɔ P Q S T U Ʊ V W Y Z a b c d e ɛ ǝ f g h i j k l m n ŋ o ɔ p q s t u ʊ v w y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/pug.yaml
+++ b/lib/hyperglot/data/pug.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: phuó
   base: A B Ɓ C D Ɗ E Ɛ F G H I Ɩ J K L M N Ɲ Ŋ O Ɔ P R S T U Ʋ V W Ⱳ Y Ƴ Za b ɓ c d ɗ e ɛ f g h i ɩ j k l m n ɲ ŋ o ɔ p r s t u ʋ v w ⱳ y ƴ z Ã Ẽ Ɛ̃ Ĩ Ɩ̃ Õ Ɔ̃ Ũ Ʋ̃ À È Ɛ̀ Ì Ɩ̀ Ò Ɔ̀ Ù Ʋ̀ Á É Ɛ́ Í Ɩ́ Ó Ɔ́ Ú Ʋ́ Ã̀ Ẽ̀ Ɛ̃̀ Ĩ̀ Ɩ̃̀ Õ̀ Ɔ̃̀ Ũ̀ Ʋ̃̀ Ã́ Ẽ́ Ɛ̃́ Ĩ́ Ɩ̃́ Ṍ Ɔ̃́ Ṹ Ʋ̃́ ã ẽ ɛ̃ ĩ ɩ̃ õ ɔ̃ ũ ʋ̃ à è ɛ̀ ì ɩ̀ ò ɔ̀ ù ʋ̀ á é ɛ́ í ɩ́ ó ɔ́ ú ʋ́ ã̀ ẽ̀ ɛ̃̀ ĩ̀ ɩ̃̀ õ̀ ɔ̃̀ ũ̀ ʋ̃̀ ã́ ẽ́ ɛ̃́ ĩ́ ɩ̃́ ṍ ɔ̃́ ṹ ʋ̃́
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/sav.yaml
+++ b/lib/hyperglot/data/sav.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: saafi-saafi
   base: A B C D E F G H I J K L M N O P R S T U W Y a b c d e f g h i j k l m n o p r s t u w y Ñ ñ Ŋ ŋ Ɓ Ɗ Ƴ ƴ ɓ ɗ ’
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/sbd.yaml
+++ b/lib/hyperglot/data/sbd.yaml
@@ -3,7 +3,7 @@ orthographies:
 - auxiliary: G H J Q Z g h j q z
   base: A B C D E Ɛ Ə F I K L M N Ŋ O Ɔ P R S T U W Y a b c d e ɛ ə f i k l m n ŋ o ɔ p r s t u w y À È Ɛ̀ Ə̀ Ì Ǹ Ò Ɔ̀ Ù Á É Í Ń Ó Ú Ǎ Ě Ə̌ Ɛ̌ Ǐ Ǒ Ɔ̌ Ǔ Ä Ë Ɛ̈ Ə̈ Ï Ö Ɔ̈ Ü Ã Ĩ Ɔ̃ Ũ à è ɛ̀ ə̀ ì ǹ ò ɔ̀ ù á é ɛ́ ə́ í ń ó ɔ́ ú ǎ ě ɛ̌ ə̌ ǐ ǒ ɔ̌ ǔ ä ë ɛ̈ ə̈ ï ö ɔ̈ ü ã ĩ ɔ̃ ũ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̌ ◌̈ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/ses.yaml
+++ b/lib/hyperglot/data/ses.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Koyraboro Senni
   base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ã Õ Ŋ Š Ž Ɲ Ẽ a b c d e f g h i j k l m n o p q r s t u v w x y z ã õ ŋ š ž ɲ ẽ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̃ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/shk.yaml
+++ b/lib/hyperglot/data/shk.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Dhøg Cøllø
   base: A Ɛ E I Ɔ O Ø U W Y B C D G H J K L M N Ŋ P R T V Á À Ä É È Ë Í Ì Ï Ó Ö Ú Ù a ɛ e i ɔ o ø u w y b c d g h j k l m n ŋ p r t v á à ä é è ë í ì ï ó ö ú ù
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̈
   script: Latin
   status: primary

--- a/lib/hyperglot/data/shz.yaml
+++ b/lib/hyperglot/data/shz.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: syenara
   base: A B C D E F G H I J K L M N O P R S T U V W Y Z a b c d e f g h i j k l m n o p r s t u v w y z Ŋ ŋ Ɔ Ɛ Ɲ ɔ ɛ ɲ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/sje.yaml
+++ b/lib/hyperglot/data/sje.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Bidumsámegiella
   base: A B D E F G H I J K L M N O P R S T U V Á Ä Å Đ Ŋ Ŧ a b d e f g h i j k l m n o p r s t u v á ä å đ ŋ ŧ ʼ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̈ ◌̊
   script: Latin
   status: primary

--- a/lib/hyperglot/data/sju.yaml
+++ b/lib/hyperglot/data/sju.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Ū Ǖ ū ǖ
   base: A B D E F G H I J K L M N O P R S T U V Y Á Ä Å Ï Ö Ü Đ Ŋ Ŧ a b d e f g h i j k l m n o p r s t u v y á ä å ï ö ü đ ŋ ŧ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̄ ◌̈ ◌̊
   script: Latin
   status: primary

--- a/lib/hyperglot/data/sld.yaml
+++ b/lib/hyperglot/data/sld.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: sɩ́saalí
   base: A B Ɓ C D E Ɛ F G H I Ɩ J K L M N Ŋ O Ɔ P R S T U Ʋ V W Y Z a b ɓ c d e ɛ f g h i ɩ j k l m n ŋ o ɔ p r s t u ʋ v w y z Á É Ɛ́ Í Ɩ́ Ó Ɔ́ Ú Ʋ́ Ã Ẽ Ɛ̃ Ĩ Ɩ̃ Õ Ɔ̃ Ʋ̃ á é ɛ́ í ɩ́ ó ɔ́ ú ʋ́ ã ẽ ɛ̃ ĩ ɩ̃ õ ɔ̃ ʋ̃
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/sme.yaml
+++ b/lib/hyperglot/data/sme.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Sámegiella
   base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Á Ä Å Æ Ö Ø Č Đ Ŋ Š Ŧ Ž a b c d e f g h i j k l m n o p q r s t u v w x y z á ä å æ ö ø č đ ŋ š ŧ ž
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̈ ◌̊ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/smj.yaml
+++ b/lib/hyperglot/data/smj.yaml
@@ -8,7 +8,7 @@ orthographies:
 - autonym: Julevusámegiella
   base: A B D E F G H I J K L M N O P R S T U V Á Ä Å Ŋ a b d e f g h i j k l m n o p r s t u v á ä å ŋ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̈ ◌̊
   script: Latin
   status: primary

--- a/lib/hyperglot/data/smn.yaml
+++ b/lib/hyperglot/data/smn.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Anarâškielâ
   base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Á Â Ä Å Ö Č Đ Ŋ Š Ž a b c d e f g h i j k l m n o p q r s t u v w x y z á â ä å ö č đ ŋ š ž
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̂ ◌̈ ◌̊ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/sms.yaml
+++ b/lib/hyperglot/data/sms.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Å Ö Ø å ö ø
   base: A B C D E F G H I J K L M N O P Q R S T U V X Y Z Â Ä Å Ö Õ Č Đ Ŋ Š Ž Ǥ Ǧ Ǩ Ǯ Ʒ a b c d e f g h i j k l m n o p q r s t u v x y z â ä å ö õ č đ ŋ š ž ǥ ǧ ǩ ǯ ʒ ʹ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̂ ◌̃ ◌̈ ◌̊ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/snf.yaml
+++ b/lib/hyperglot/data/snf.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: noon
   base: A B C D E F G H I J K L M N O P R S T U W Y a b c d e f g h i j k l m n o p r s t u w y É Ë Í Ñ Ó Ú é ë í ñ ó ú Ŋ ŋ Ɓ Ɗ Ƴ ƴ ɓ ɗ ʼ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̈ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/soy.yaml
+++ b/lib/hyperglot/data/soy.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: mɛyɔ́pɛ
   base: A C E Ɛ F H I K L M N Ŋ O Ɔ P R S T U W Y Á É Í Ó Õ Ú Ĩ Ũ Ṍ Ṹ Ẽ a c e ɛ f h i k l m n ŋ o ɔ p r s t u w y á é í ó õ ú ĩ ũ ṍ ṹ ẽ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/srr.yaml
+++ b/lib/hyperglot/data/srr.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Seereer
   base: A B Ɓ C Ƈ D Ɗ E F G H I J K L M N Ñ Ŋ O P Ƥ Q R S T Ƭ U W X Y Ƴ a b ɓ c ƈ d ɗ e f g h i j k l m n ñ ŋ o p ƥ q r s t ƭ u w x y ƴ '
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/sxw.yaml
+++ b/lib/hyperglot/data/sxw.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Q R q r
   base: A B C D Ɖ E Ɛ F G Ɣ H I J K L M N Ŋ O Ɔ P S T U V W X Y Z a b c d ɖ e ɛ f g ɣ h i j k l m n ŋ o ɔ p s t u v w x y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/tay.yaml
+++ b/lib/hyperglot/data/tay.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Č Š Ž Ḳ č š ž ḳ
   base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ŋ Ə a b c d e f g h i j k l m n o p q r s t u v w x y z ŋ ə ’
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̌ ◌̣
   script: Latin
   status: primary

--- a/lib/hyperglot/data/tbz.yaml
+++ b/lib/hyperglot/data/tbz.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: ditammari
   base: A B C D Đ E Ɛ F H I K L M N Ŋ O Ɔ P R S T U W X Y Z À Á Ã È É Ì Í Ĩ Ḿ Ń Ǹ Ò Ó Ù Ú Ú Ũ a b c d đ e ɛ f h i k l m n ŋ o ɔ p r s t u w x y z à á ã è é ì í ĩ ḿ ń ǹ ò ó ù ú ú ũ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌́ ◌̀ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/tem.yaml
+++ b/lib/hyperglot/data/tem.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: KʌThemnɛ
   base: A Ʌ B D E Ɛ Ə F G H I K L M N Ŋ O Ɔ P R S T U W a ʌ b d e ɛ ə f g h i k l m n ŋ o ɔ p r s t u w
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/teo.yaml
+++ b/lib/hyperglot/data/teo.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: F Q Z f q z
   base: A B C D E G H I J K L M N O P R S T U V W X Y Ŋ a b c d e g h i j k l m n o p r s t u v w x y ŋ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: historical
 - autonym: Atɛsɔ

--- a/lib/hyperglot/data/tik.yaml
+++ b/lib/hyperglot/data/tik.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Q q
   base: A Æ B Ɓ C D Ɗ Ɛ F G H I J K L M N Ŋ O P R S T U V W Y Z Ꞌ a b ɓ c d ɗ ɛ f g h j k l m n ŋ o p r s t u v w y z ꞌ À Æ̀ È Ɛ̀ Ì M̀ Ǹ Ŋ̀ Ò Ù Â Æ̂ Ê Ɛ̂ Î Ô Û Ǎ Æ̌ Ě Ɛ̌ Ǐ Ǒ Ǔ à æ̀ è ɛ̀ ì m̀ ǹ ŋ̀ ò ù â æ̂ ê ɛ̂ î ô û ǎ æ̌ ě ɛ̌ ǐ ǒ ǔ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌̂ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/tnr.yaml
+++ b/lib/hyperglot/data/tnr.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: ménik
   base: A B C D E F G H I J K L M N O P R S T U W Y a b c d e f g h i j k l m n o p r s t u w y È É Ë Ñ Ó è é ë ñ ó Ŋ ŋ Ŝ ŝ Ɓ Ɗ Ƴ ƴ ɓ ɗ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̂ ◌̈ ◌̃
   script: Latin
   status: primary

--- a/lib/hyperglot/data/tod.yaml
+++ b/lib/hyperglot/data/tod.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: lɔgɔma
   base: A B D E F G I J K L M N O P S T U V W Y Z a b d e f g i j k l m n o p s t u v w y z Ŋ ŋ Ɓ Ɔ Ɗ Ǝ Ɛ Ɠ Ɲ Ʋ ǝ ɓ ɔ ɗ ɛ ɠ ɲ ʋ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/ttq.yaml
+++ b/lib/hyperglot/data/ttq.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: ʔ
   base: A B C D E F G H I J J̌ K L M N O Q R S T U W X Y Z a b c d e f g h i j k l m n o q r s t u w x y z Â Ê Î Ô Û â ê î ô û Ă ă Ŋ ŋ Š š Ǝ Ɣ ǝ Ǧ ǧ ǰ ɣ Ḍ ḍ Ḷ ḷ Ṣ ṣ Ṭ ṭ Ẓ ẓ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̂ ◌̆ ◌̌ ◌̣
   script: Latin
   status: primary

--- a/lib/hyperglot/data/twq.yaml
+++ b/lib/hyperglot/data/twq.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: V v
   base: A B C D E F G H I J K L M N O P Q R S T U W X Y Z Ã Õ Ŋ Š Ž Ɲ Ẽ a b c d e f g h i j k l m n o p q r s t u w x y z ã õ ŋ š ž ɲ ẽ ’
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̃ ◌̌
   script: Latin
   status: primary

--- a/lib/hyperglot/data/wci.yaml
+++ b/lib/hyperglot/data/wci.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: wacigbe
   base: A B C D Ɖ E Ɛ F Ƒ G Ɣ H X I J K L M N Ŋ Ɔ P S T U Ʋ V W Y Z a b c d ɖ e ɛ f ƒ g ɣ h x i j k l m n ŋ ɔ p s t u ʋ v w y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/wol.yaml
+++ b/lib/hyperglot/data/wol.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Wolof
   base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z À Ã É Ë Ñ Ó Ŋ a b c d e f g h i j k l m n o p q r s t u v w x y z à ã é ë ñ ó ŋ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̃ ◌̈
   script: Latin
   status: primary

--- a/lib/hyperglot/data/wwa.yaml
+++ b/lib/hyperglot/data/wwa.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: Yoabu
   base: A B C D E Ɛ F I K M N Ŋ O Ɔ P R S T U W Y a b c d e ɛ f i k m n ŋ o ɔ p r s t u w y
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   note: Ŋ/ŋ are not included in CENALA 1990 nor CENALA 2008 but are included in Hartell 1993 and are used in https://www.webonary.org/waama/ or the Waama Bible translation published in Wycliffe 1994.
   script: Latin
   status: primary

--- a/lib/hyperglot/data/xsm.yaml
+++ b/lib/hyperglot/data/xsm.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: Ə ə
   base: A Ǝ B C D E Ɛ F G H I Ɩ J K L M N Ŋ O Ɔ P R S T U Ʋ V W Y Z a ǝ b c d e ɛ f g h i ɩ j k l m n ŋ o ɔ p r s t u ʋ v w y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   note: The Bureau of Ghana Languages 1976 orthography did not use Ǝ Ɩ Ʋ ǝ ɩ ʋ.
   script: Latin
   status: primary

--- a/lib/hyperglot/data/xwe.yaml
+++ b/lib/hyperglot/data/xwe.yaml
@@ -3,7 +3,7 @@ orthographies:
 - autonym: xwelagbe
   base: A B C D Ɖ E Ɛ F G Ɣ H X I J K L M N Ŋ Ɔ P S T U V W Y Z a b c d ɖ e ɛ f g ɣ h x i j k l m n ŋ ɔ p s t u v w y z
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   script: Latin
   status: primary
 source:

--- a/lib/hyperglot/data/yav.yaml
+++ b/lib/hyperglot/data/yav.yaml
@@ -4,7 +4,7 @@ orthographies:
   auxiliary: J Q R X Z j q r x z
   base: A B C D E F G H I K L M N O P S T U V W Y À Á Â È É Ì Í Î Ò Ó Ô Ù Ú Û Ā Ī Ŋ Ō Ū Ǎ Ǒ Ǔ Ɔ Ɛ a b c d e f g h i k l m n o p s t u v w y à á â è é ì í î ò ó ô ù ú û ā ī ŋ ō ū ǎ ǒ ǔ ɔ ɛ
   design_requirements:
-  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ reaching cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
+  - There are two common design variants both encoded as Ŋ, one resembling the lowercase ŋ on cap height favoured in African languages, and the other resembling N with J as the second stem favoured in Sami languages.
   marks: ◌̀ ◌́ ◌̂ ◌̄ ◌̌
   script: Latin
   status: primary


### PR DESCRIPTION
Several languages have the same note for the shape of Ŋ but 57 have it with "ŋ reaching cap height" and 67 have it with "ŋ on cap height". This replaces the text of the 57 with the most frequent one of the 67.
