### PR TITLE
[xav] Xavánte uses 3 orthographies

### DIFF
--- a/lib/hyperglot/data/xav.yaml
+++ b/lib/hyperglot/data/xav.yaml
@@ -1,13 +1,34 @@
 name: Xavánte
 orthographies:
 - autonym: A’uwẽ
-  base: A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ã É Ẽ Ô Õ Ö Ĩ a b c d e f g h i j k l m n o p q r s t u v w x y z ã é ẽ ô õ ö ĩ ’
-  marks: ◌́ ◌̂ ◌̃ ◌̈
+  base: A B C D E F G H I J K L M N NH O P Q R S T U V W X Y Z Â Ã É Ẽ Ô Õ Ĩ a b c d e f g h i j k l m n nh o p q r s t u v w x y z â ã é ẽ ô õ ĩ ’
+  auxiliary: Ĩ̱ ĩ̱
+  marks: ◌́ ◌̂ ◌̃ ◌̱
+  preferred_as_group: true
   script: Latin
   status: primary
+  note: SIL orthography.
+- autonym: A’uwẽ (MSM)
+  base: A B C D E F G H I J K L M N NH O P Q R TS T U V W X Y DZ Ã É Ẽ Ô Õ Ö Ĩ a b c d e f g h i j k l m n nh o p q r ts t u v w x y dz ã é ẽ ô õ ö ĩ ’
+  marks: ◌́ ◌̂ ◌̃ ◌̈
+  preferred_as_group: true
+  script: Latin
+  status: secondary
+  note: MSM orthography.
+- autonym: Etêñiritipa
+  base: A B C D E F G H I J K L M N Ñ O P Q R S T U V W X Y Z Ã É Ẽ Ô Õ Ö Ĩ a b c d e f g h i j k l m n ñ o p q r s t u v w x y z ã é ẽ ô õ ö ĩ ’
+  marks: ◌́ ◌̂ ◌̃ ◌̈
+  preferred_as_group: true
+  script: Latin
+  status: local
+  note: Pimentel Barbosa (Etêñiritipa) orthography.
 source:
 - Omniglot
+- Xavante Dictionary, Webonary, https://www.webonary.org/xavante
+- "J. Hall, R. A. McLeod and V. Mitchell, Pequeno dicionário: Xavante-Português, Português-Xavante, Cuiabá: Sociedade Internacional de Linguística, 2004"
+- "W. A. Pickering, A fonologia xavante: uma revisitação, 2010"
 speakers: 9600
 speakers_date: 2006
 status: living
 validity: draft
+note: "The current SIL orthography uses â instead of ö and uses ĩ̱ in some works for first person pronominal prefix (see https://www.webonary.org/xavante/?lang=en), the Pimentel Barbosa (Etêñiritipa) orthography uses ñ instead of nh, the MSM orthography uses ts and dz instead of s and z."


### PR DESCRIPTION
Xavánte [xav] uses 3 orthographies. [Pickering 2010 p. 171](http://etnolinguistica.wdfiles.com/local--files/tese%3Apickering-2010/Pickering_WilliamAlfred_D.pdf#page=181) shows a comparison between the 3.
The current SIL orthography uses â instead of ö and uses ĩ̱ for first person pronominal prefix (see https://www.webonary.org/xavante/?lang=en), the Pimentel Barbosa (Etêñiritipa) orthography uses ñ instead of nh, the MSM orthography uses ts and dz instead of s and z.
