### PR TITLE
Fix entry point for `hyperglot-export`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name="hyperglot",
               "hyperglot-data = hyperglot.cli:data",
               "hyperglot-validate = hyperglot.validate:validate",
               "hyperglot-save = hyperglot.cli:save_sorted",
-              "hyperglot-export = lib.hyperglot.cli:export"
+              "hyperglot-export = hyperglot.cli:export"
           ]
       },
       install_requires=[


### PR DESCRIPTION
The entry point for `hyperglot-export` currently points to an invalid module. I assume that a previous refactor moved things out of a `lib` wrapper module, and that this was just an oversight. The tool seems to work again after applying this fix.